### PR TITLE
chore: localize admin messages and frontend

### DIFF
--- a/.github/workflows/ci-webapp.yml
+++ b/.github/workflows/ci-webapp.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write **/*.{js,jsx,css,html}
+          prettier_options: --check **/*.{js,jsx,css,html}
           only_changed: True
   ruff:
     runs-on: ubuntu-latest

--- a/asreview/webapp/_api/admin.py
+++ b/asreview/webapp/_api/admin.py
@@ -68,7 +68,7 @@ def get_users():
 
         return jsonify({"users": user_list}), 200
     except SQLAlchemyError as e:
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
 
 
 @bp.route("/users", methods=["POST"])
@@ -98,7 +98,7 @@ def create_user():
 
         if existing_user:
             return jsonify(
-                {"message": "User with this identifier or email already exists"}
+                {"message": "この識別子またはメールアドレスのユーザーは既に存在します"}
             ), 409
 
         # Create new user
@@ -119,7 +119,7 @@ def create_user():
 
         return jsonify(
             {
-                "message": "User created successfully",
+                "message": "ユーザーが正常に作成されました",
                 "user": {
                     "id": user.id,
                     "identifier": user.identifier,
@@ -132,13 +132,13 @@ def create_user():
 
     except ValueError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Validation error: {str(e)}"}), 400
+        return jsonify({"message": f"検証エラー: {str(e)}"}), 400
     except IntegrityError as e:
         DB.session.rollback()
-        return jsonify({"message": f"User already exists: {str(e)}"}), 409
+        return jsonify({"message": f"ユーザーは既に存在します: {str(e)}"}), 409
     except SQLAlchemyError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
 
 
 @bp.route("/users/<int:user_id>", methods=["PUT"])
@@ -148,7 +148,7 @@ def update_user(user_id):
     try:
         user = DB.session.get(User, user_id)
         if not user:
-            return jsonify({"message": "User not found"}), 404
+            return jsonify({"message": "ユーザーが見つかりません"}), 404
 
         data = request.get_json()
 
@@ -175,14 +175,14 @@ def update_user(user_id):
                 user.hashed_password = User.create_password_hash(data["password"])
             else:
                 return jsonify(
-                    {"message": "Cannot set password for non-asreview users"}
+                    {"message": "asreview 以外のユーザーにはパスワードを設定できません"}
                 ), 400
 
         DB.session.commit()
 
         return jsonify(
             {
-                "message": "User updated successfully",
+                "message": "ユーザーが正常に更新されました",
                 "user": {
                     "id": user.id,
                     "identifier": user.identifier,
@@ -195,13 +195,13 @@ def update_user(user_id):
 
     except ValueError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Validation error: {str(e)}"}), 400
+        return jsonify({"message": f"検証エラー: {str(e)}"}), 400
     except IntegrityError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Integrity error: {str(e)}"}), 409
+        return jsonify({"message": f"整合性エラー: {str(e)}"}), 409
     except SQLAlchemyError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
 
 
 @bp.route("/users/<int:user_id>", methods=["DELETE"])
@@ -211,7 +211,7 @@ def delete_user(user_id):
     try:
         user = DB.session.get(User, user_id)
         if not user:
-            return jsonify({"message": "User not found"}), 404
+            return jsonify({"message": "ユーザーが見つかりません"}), 404
 
         # Store user info for response
         user_info = {
@@ -225,12 +225,12 @@ def delete_user(user_id):
         DB.session.commit()
 
         return jsonify(
-            {"message": "User deleted successfully", "deleted_user": user_info}
+            {"message": "ユーザーが正常に削除されました", "deleted_user": user_info}
         ), 200
 
     except SQLAlchemyError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
 
 
 @bp.route("/users/<int:user_id>", methods=["GET"])
@@ -240,7 +240,7 @@ def get_user(user_id):
     try:
         user = DB.session.get(User, user_id)
         if not user:
-            return jsonify({"message": "User not found"}), 404
+            return jsonify({"message": "ユーザーが見つかりません"}), 404
 
         user_data = {
             "id": user.id,
@@ -257,7 +257,7 @@ def get_user(user_id):
         return jsonify({"user": user_data}), 200
 
     except SQLAlchemyError as e:
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
 
 
 @bp.route("/projects", methods=["GET"])
@@ -283,11 +283,11 @@ def get_all_projects():
                     "owner_id": db_project.owner_id,
                     "owner_name": (db_project.owner.name or db_project.owner.identifier)
                     if db_project.owner
-                    else "Unknown",
+                    else "不明",
                     "owner_email": db_project.owner.email
                     if db_project.owner
-                    else "Unknown",
-                    "name": "Unknown",  # Default value
+                    else "不明",
+                    "name": "不明",  # Default value
                     "created_at_unix": None,
                     "version": None,
                     "mode": None,
@@ -303,7 +303,7 @@ def get_all_projects():
                         # Update with data from project.json
                         project_data.update(
                             {
-                                "name": project_config.get("name", "Unnamed Project"),
+                                "name": project_config.get("name", "名称未設定"),
                                 "created_at_unix": project_config.get(
                                     "created_at_unix"
                                 ),
@@ -323,13 +323,15 @@ def get_all_projects():
 
                     except (json.JSONDecodeError, IOError) as e:
                         logging.warning(
-                            f"Could not read project.json for {db_project.project_id}: {e}"
+                            f"{db_project.project_id} の project.json を読み込めませんでした: {e}"
                         )
                         # Keep error status (already set), add error details
-                        project_data["error"] = "Could not read project configuration"
+                        project_data["error"] = (
+                            "プロジェクトの設定を読み込めませんでした"
+                        )
                 else:
                     # Keep error status (already set), add error details
-                    project_data["error"] = "Project configuration file not found"
+                    project_data["error"] = "プロジェクト設定ファイルが見つかりません"
 
                 project_list.append(project_data)
 
@@ -345,11 +347,11 @@ def get_all_projects():
                             db_project.owner.name or db_project.owner.identifier
                         )
                         if db_project.owner
-                        else "Unknown",
+                        else "不明",
                         "owner_email": db_project.owner.email
                         if db_project.owner
-                        else "Unknown",
-                        "name": "Error Loading Project",
+                        else "不明",
+                        "name": "プロジェクトの読み込みエラー",
                         "status": "error",
                         "error": str(e),
                     }
@@ -370,10 +372,12 @@ def get_all_projects():
         ), 200
 
     except SQLAlchemyError as e:
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
     except Exception as e:
         logging.error(f"Error retrieving projects: {e}")
-        return jsonify({"message": f"Error retrieving projects: {str(e)}"}), 500
+        return jsonify(
+            {"message": f"プロジェクトの取得中にエラーが発生しました: {str(e)}"}
+        ), 500
 
 
 @bp.route("/projects/<int:project_id>/transfer-ownership", methods=["POST"])
@@ -385,22 +389,22 @@ def transfer_project_ownership(project_id):
         new_owner_id = data.get("new_owner_id")
 
         if not new_owner_id:
-            return jsonify({"message": "new_owner_id is required"}), 400
+            return jsonify({"message": "new_owner_id が必要です"}), 400
 
         # Get the project
         project = DB.session.get(Project, project_id)
         if not project:
-            return jsonify({"message": "Project not found"}), 404
+            return jsonify({"message": "プロジェクトが見つかりません"}), 404
 
         # Get the new owner
         new_owner = DB.session.get(User, new_owner_id)
         if not new_owner:
-            return jsonify({"message": "New owner not found"}), 404
+            return jsonify({"message": "新しい所有者が見つかりません"}), 404
 
         # Check if the new owner is different from current owner
         if project.owner_id == new_owner_id:
             return jsonify(
-                {"message": "User is already the owner of this project"}
+                {"message": "このユーザーは既にこのプロジェクトの所有者です"}
             ), 400
 
         # Store old owner reference for cleanup
@@ -428,7 +432,7 @@ def transfer_project_ownership(project_id):
 
         return jsonify(
             {
-                "message": "Project ownership transferred successfully",
+                "message": "プロジェクトの所有権が正常に移転されました",
                 "project": {
                     "id": project.id,
                     "project_id": project.project_id,
@@ -443,15 +447,15 @@ def transfer_project_ownership(project_id):
 
     except ValueError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Validation error: {str(e)}"}), 400
+        return jsonify({"message": f"検証エラー: {str(e)}"}), 400
     except SQLAlchemyError as e:
         DB.session.rollback()
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
     except Exception as e:
         DB.session.rollback()
         logging.error(f"Error transferring project ownership: {e}")
         return jsonify(
-            {"message": f"Error transferring project ownership: {str(e)}"}
+            {"message": f"プロジェクトの所有権移転中にエラーが発生しました: {str(e)}"}
         ), 500
 
 
@@ -463,31 +467,35 @@ def add_project_member(project_id):
         # Get the user ID from request JSON
         data = request.get_json()
         if not data or "user_id" not in data:
-            return jsonify({"message": "User ID is required"}), 400
+            return jsonify({"message": "ユーザーIDが必要です"}), 400
 
         user_id = data["user_id"]
 
         # Get project
         project = DB.session.get(Project, project_id)
         if not project:
-            return jsonify({"message": "Project not found"}), 404
+            return jsonify({"message": "プロジェクトが見つかりません"}), 404
 
         # Get user
         user = DB.session.get(User, user_id)
         if not user:
-            return jsonify({"message": "User not found"}), 404
+            return jsonify({"message": "ユーザーが見つかりません"}), 404
 
         # Check if user is already the owner
         if user.id == project.owner_id:
-            return jsonify({"message": "Cannot add project owner as member"}), 400
+            return jsonify(
+                {
+                    "message": "プロジェクト所有者をメンバーとして追加することはできません"
+                }
+            ), 400
 
         # Check if user is already a collaborator
         if user in project.collaborators:
-            return jsonify({"message": "User is already a member"}), 400
+            return jsonify({"message": "ユーザーは既にメンバーです"}), 400
 
         # Check if user has a pending invitation
         if user in project.pending_invitations:
-            return jsonify({"message": "User already has a pending invitation"}), 400
+            return jsonify({"message": "ユーザーには既に保留中の招待があります"}), 400
 
         # Add user as collaborator
         project.collaborators.append(user)
@@ -501,17 +509,19 @@ def add_project_member(project_id):
         user_props = get_user_project_properties(user, project, current_user)
 
         return jsonify(
-            {"message": "Member added successfully", "user": user_props}
+            {"message": "メンバーが正常に追加されました", "user": user_props}
         ), 200
 
     except SQLAlchemyError as e:
         DB.session.rollback()
         logging.exception(e)
-        return jsonify({"message": f"Database error: {str(e)}"}), 500
+        return jsonify({"message": f"データベースエラー: {str(e)}"}), 500
     except Exception as e:
         DB.session.rollback()
         logging.exception(e)
-        return jsonify({"message": f"Error adding member: {str(e)}"}), 500
+        return jsonify(
+            {"message": f"メンバー追加中にエラーが発生しました: {str(e)}"}
+        ), 500
 
 
 # Please note: the Task Manager is running in an independent process. It might
@@ -593,7 +603,7 @@ def get_task_queue_status():
     except Exception as e:
         logging.error(f"Error retrieving task queue status: {e}")
         return jsonify(
-            {"message": f"Error retrieving task queue status: {str(e)}"}
+            {"message": f"タスクキューの状態取得中にエラーが発生しました: {str(e)}"}
         ), 500
 
 
@@ -641,14 +651,16 @@ def reset_task_queue():
 
         return jsonify(
             {
-                "message": "Task queue reset successfully",
+                "message": "タスクキューのリセットに成功しました",
                 "cleared_waiting_tasks": waiting_count,
             }
         ), 200
 
     except Exception as e:
         logging.error(f"Error resetting task queue: {e}")
-        return jsonify({"message": f"Error resetting task queue: {str(e)}"}), 500
+        return jsonify(
+            {"message": f"タスクキューのリセット中にエラーが発生しました: {str(e)}"}
+        ), 500
 
 
 def _ensure_utc_timezone(dt):
@@ -687,18 +699,18 @@ def _get_task_manager_status():
         else:
             return {
                 "status": "no_response",
-                "error": "Task Manager connected but sent no data",
+                "error": "タスクマネージャーに接続しましたがデータが送信されませんでした",
             }
 
     except socket.timeout:
         return {
             "status": "timeout",
-            "error": "Task Manager did not respond within 3 seconds",
+            "error": "タスクマネージャーが3秒以内に応答しませんでした",
         }
     except ConnectionRefusedError:
-        return {"status": "offline", "error": "Task Manager is not running"}
+        return {"status": "offline", "error": "タスクマネージャーが起動していません"}
     except Exception as e:
         return {
             "status": "error",
-            "error": f"Failed to connect to Task Manager: {str(e)}",
+            "error": f"タスクマネージャーに接続できませんでした: {str(e)}",
         }

--- a/asreview/webapp/src/AdminComponents/UsersComponent.js
+++ b/asreview/webapp/src/AdminComponents/UsersComponent.js
@@ -25,6 +25,7 @@ import { UserFormDialog } from "AdminComponents";
 import UserCard from "./UserCard";
 import DeleteConfirmationDialog from "./DeleteConfirmationDialog";
 import { StyledLightBulb } from "StyledComponents/StyledLightBulb";
+import { useAuth } from "hooks/useAuth";
 
 const UsersComponent = () => {
   const [selectedTab, setSelectedTab] = React.useState(0);
@@ -46,6 +47,8 @@ const UsersComponent = () => {
     refetchOnWindowFocus: false,
     retry: 2,
   });
+
+  const { isAdmin } = useAuth();
 
   // Process the users data into categories
   const processUsersData = React.useMemo(() => {
@@ -339,7 +342,7 @@ const UsersComponent = () => {
                           user={user}
                           onEdit={handleEditUser}
                           onDelete={handleDeleteUser}
-                          isAdmin={true} // TODO: Get from actual auth context
+                          isAdmin={isAdmin}
                         />
                       </Grid>
                     ))}

--- a/asreview/webapp/templates/emails/confirm_account.html
+++ b/asreview/webapp/templates/emails/confirm_account.html
@@ -1,14 +1,13 @@
-<p>Hello {{ name }},</p>
+<p>{{ name }} さん、こんにちは。</p>
 
 {% if email_type == "create" %}
-<p>Thank you for joining ASReview. You are almost ready!</p>
+<p>ASReviewへのご登録ありがとうございます。あともう少しで完了です。</p>
 {% elif email_type == "change_email" %}
-<p>You have changed your email address.</p>
+<p>メールアドレスが変更されました。</p>
 {% endif %}
 
 <p>
-  Below you find a 6-digits code. Use it to confirm your email address. Please
-  note that the code will expire in 20 minutes.
+  下記に6桁のコードがあります。メールアドレスの確認にご利用ください。なお、このコードは20分で期限切れとなります。
 </p>
 
 <h2 style="margin: 0; text-align: center; font-size: 24px; color: #333">
@@ -16,10 +15,9 @@
 </h2>
 
 <p>
-  After confirmation you will be redirected to the signin page. Use your account
-  credentials and start using ASReview.
+  確認後、サインインページにリダイレクトされます。アカウントの認証情報を使用してASReviewをお楽しみください。
 </p>
 
-<p>Regards,</p>
+<p>よろしくお願いいたします。</p>
 
-<p>The ASReview Team</p>
+<p>ASReview チーム</p>

--- a/asreview/webapp/templates/emails/forgot_password.html
+++ b/asreview/webapp/templates/emails/forgot_password.html
@@ -1,14 +1,13 @@
-<p>Hello {{ name }},</p>
+<p>{{ name }} さん、こんにちは。</p>
 
 <p>
-  Use the code below to reset your password. Please note that the code will
-  expire in 20 minutes.
+  パスワードをリセットするには以下のコードをご利用ください。このコードは20分で期限切れとなります。
 </p>
 
 <h2 style="margin: 0; text-align: center; font-size: 24px; color: #333">
   {{ token }}
 </h2>
 
-<p>Regards,</p>
+<p>よろしくお願いいたします。</p>
 
-<p>The ASReview Team</p>
+<p>ASReview チーム</p>

--- a/asreview/webapp/tests/integration_tests/utils.py
+++ b/asreview/webapp/tests/integration_tests/utils.py
@@ -60,7 +60,6 @@ def select_from_dropdown(driver, parent, data_value):
     WebDriverWait(driver, 60).until(EC.invisibility_of_element_located(element))
 
 
-# TODO APPLY THIS FUNCTION
 def fill_text_field_by_id(driver, field_id, value, wait_time=60):
     selector = (By.CSS_SELECTOR, f"input#{field_id}")
     WebDriverWait(driver, wait_time).until(EC.presence_of_element_located(selector))
@@ -101,7 +100,7 @@ def create_account(driver, base_url, account_data):
 
     # enter form data
     for field_id, value in form_field_values:
-        driver.find_element(By.CSS_SELECTOR, f"input#{field_id}").send_keys(value)
+        fill_text_field_by_id(driver, field_id, value)
 
     # wait until create button is clickable and enabled
     click_element(driver, "button#create-profile")


### PR DESCRIPTION
## Summary
- run Prettier in check mode in webapp workflow
- derive admin flag from auth context
- translate email templates to Japanese and use helper in tests
- localize admin API responses

## Testing
- `ruff format asreview/webapp/_api/admin.py asreview/webapp/tests/integration_tests/utils.py`
- `ruff check asreview/webapp/_api/admin.py asreview/webapp/tests/integration_tests/utils.py`
- `npx prettier src/AdminComponents/UsersComponent.js templates/emails/confirm_account.html templates/emails/forgot_password.html --check`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'asreview._version')*
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ab01a208333b7bdfbb581db5d17